### PR TITLE
Ensure custom template loads for plugin pages

### DIFF
--- a/fc-auth.php
+++ b/fc-auth.php
@@ -9,6 +9,20 @@ Author: Silas
 if ( ! defined('ABSPATH') ) exit;
 
 // --------------------------------
+// Lade fc-template.php aus Plugin-Verzeichnis
+// --------------------------------
+add_filter('template_include', function($template){
+    if (is_page()) {
+        $slug = get_page_template_slug(get_queried_object_id());
+        if ($slug === 'fc-template.php') {
+            $file = plugin_dir_path(__FILE__) . 'fc-template.php';
+            if (file_exists($file)) return $file;
+        }
+    }
+    return $template;
+});
+
+// --------------------------------
 // Aktivierung: Login-Seite anlegen
 // --------------------------------
 register_activation_hook(__FILE__, function(){

--- a/fun-casino.php
+++ b/fun-casino.php
@@ -8,6 +8,20 @@ Author: Silas
 
 if ( ! defined('ABSPATH') ) exit;
 
+// --------------------------------
+// Lade fc-template.php aus Plugin-Verzeichnis
+// --------------------------------
+add_filter('template_include', function($template){
+    if (is_page()) {
+        $slug = get_page_template_slug(get_queried_object_id());
+        if ($slug === 'fc-template.php') {
+            $file = plugin_dir_path(__FILE__) . 'fc-template.php';
+            if (file_exists($file)) return $file;
+        }
+    }
+    return $template;
+});
+
 // ------------------------------
 // Activation: create tables & pages
 // ------------------------------


### PR DESCRIPTION
## Summary
- Load `fc-template.php` from the plugin directory when selected as a page template
- Applies to both the FC Auth and Fun Casino plugins, removing theme headers/footers

## Testing
- `php -l fc-auth.php`
- `php -l fun-casino.php`
- `php -l fc-template.php`


------
https://chatgpt.com/codex/tasks/task_e_68c81781acd483239d45307dfec21822