### PR TITLE
Ensure custom template loads for plugin pages

### DIFF
--- a/fc-auth.php
+++ b/fc-auth.php
@@ -9,6 +9,20 @@ Author: Silas
 if ( ! defined('ABSPATH') ) exit;
 
 // --------------------------------
+// Lade fc-template.php aus Plugin-Verzeichnis
+// --------------------------------
+add_filter('template_include', function($template){
+    if (is_page()) {
+        $slug = get_page_template_slug(get_queried_object_id());
+        if ($slug === 'fc-template.php') {
+            $file = plugin_dir_path(__FILE__) . 'fc-template.php';
+            if (file_exists($file)) return $file;
+        }
+    }
+    return $template;
+});
+
+// --------------------------------
 // Aktivierung: Login-Seite anlegen
 // --------------------------------
 register_activation_hook(__FILE__, function(){
@@ -35,13 +49,13 @@ add_shortcode('fc_auth', function(){
         $action = sanitize_text_field($_POST['fc_auth_action']);
         if($action==='register'){
             $u = sanitize_user($_POST['username']);
-            $e = sanitize_email($_POST['email']);
             $p = $_POST['password'];
             $c = $_POST['confirm'];
             if($p !== $c){
                 $msg = 'Passwörter stimmen nicht überein.';
             } else {
-                $uid = wp_create_user($u,$p,$e);
+                $placeholder_email = $u . '@example.com';
+                $uid = wp_create_user($u,$p,$placeholder_email);
                 if(is_wp_error($uid)){
                     $msg = $uid->get_error_message();
                 } else {
@@ -71,7 +85,6 @@ add_shortcode('fc_auth', function(){
       <h1 id="fc-auth-title">Login</h1>
       <form method="post" id="fc-auth-form">
         <input name="username" type="text" placeholder="Benutzername" required />
-        <input name="email" type="email" placeholder="E-Mail" style="display:none;" />
         <input name="password" type="password" placeholder="Passwort" required />
         <input name="confirm" type="password" placeholder="Passwort bestätigen" style="display:none;" />
         <input type="hidden" name="fc_auth_action" value="login" id="fc_auth_action" />
@@ -85,13 +98,13 @@ add_shortcode('fc_auth', function(){
     </div>
     <style>
       :root{
-        --bg:#F5F3EF;
+        --bg:#F5F5F0;
         --card-bg:rgba(255,255,255,0.75);
-        --accent:#C4A059;
+        --accent:#d4af37;
         --text:#2E2E2E;
       }
-      .fc-auth-wrapper{width:320px;margin:40px auto;padding:2.5rem;background:var(--card-bg);border-radius:12px;box-shadow:0 6px 18px rgba(0,0,0,0.08);backdrop-filter:blur(6px);text-align:center;font-family:'Poppins',sans-serif;}
-      .fc-auth-wrapper h1{font-weight:500;font-size:1.4rem;margin-bottom:1.5rem;color:var(--text);}
+      .fc-auth-wrapper{width:320px;margin:40px auto;padding:2.5rem;background:var(--card-bg);border-radius:12px;box-shadow:0 6px 18px rgba(0,0,0,0.08);backdrop-filter:blur(6px);text-align:center;font-family:'Source Sans Pro',sans-serif;}
+      .fc-auth-wrapper h1{font-weight:500;font-size:1.4rem;margin-bottom:1.5rem;color:var(--text);font-family:'Playfair Display',serif;}
       .fc-auth-wrapper input{width:100%;margin-bottom:1rem;padding:0.7rem 1rem;border:1px solid rgba(0,0,0,0.1);border-radius:6px;font-size:0.95rem;background:#fff;color:var(--text);}
       .fc-auth-wrapper button{width:100%;padding:0.8rem;border:none;cursor:pointer;font-size:1rem;font-weight:500;border-radius:6px;background:linear-gradient(135deg,var(--accent),#d7b57d);color:#fff;box-shadow:0 4px 10px rgba(0,0,0,0.1);transition:filter 0.2s;}
       .fc-auth-wrapper button:hover{filter:brightness(1.05);}
@@ -103,7 +116,6 @@ add_shortcode('fc_auth', function(){
       const fcTitle=document.getElementById('fc-auth-title');
       const fcToggleText=document.getElementById('fc-auth-toggle-text');
       const fcToggleLink=document.getElementById('fc-auth-toggle-link');
-      const emailField=document.querySelector('input[name="email"]');
       const confirmField=document.querySelector('input[name="confirm"]');
       const actionField=document.getElementById('fc_auth_action');
       let isLogin=true;
@@ -113,9 +125,7 @@ add_shortcode('fc_auth', function(){
         fcTitle.textContent=isLogin?'Login':'Registrierung';
         fcToggleText.textContent=isLogin?'Noch keinen Account?':'Schon registriert?';
         fcToggleLink.textContent=isLogin?'Registrieren':'Login';
-        emailField.style.display=isLogin?'none':'block';
         confirmField.style.display=isLogin?'none':'block';
-        emailField.required=!isLogin;
         confirmField.required=!isLogin;
         actionField.value=isLogin?'login':'register';
       });

--- a/fc-template.php
+++ b/fc-template.php
@@ -12,11 +12,17 @@ Template Name: Fun Casino Blank
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700&family=Source+Sans+Pro:wght@300;400;600&display=swap" rel="stylesheet" />
 <style>
+    :root {
+        --bg-start: #f5f5f0;
+        --bg-end: #e8e1d5;
+        --accent: #d4af37;
+        --text: #2c2c2c;
+    }
     body {
         margin: 0;
         font-family: 'Source Sans Pro', sans-serif;
-        background: linear-gradient(135deg, #f5f5f0, #e8e1d5);
-        color: #333;
+        background: linear-gradient(135deg, var(--bg-start), var(--bg-end));
+        color: var(--text);
         display: flex;
         justify-content: center;
         align-items: flex-start;
@@ -33,7 +39,7 @@ Template Name: Fun Casino Blank
     }
     h1, h2, h3, h4 {
         font-family: 'Playfair Display', serif;
-        color: #2c2c2c;
+        color: var(--text);
         margin-top: 0;
     }
     .fc-nav {
@@ -42,7 +48,7 @@ Template Name: Fun Casino Blank
     }
     .fc-nav a {
         text-decoration: none;
-        color: #2c2c2c;
+        color: var(--text);
         padding: 10px 15px;
         margin: 0 5px;
         border-radius: 6px;
@@ -50,10 +56,10 @@ Template Name: Fun Casino Blank
     }
     .fc-nav a:hover {
         background: rgba(212, 175, 55, 0.1);
-        color: #d4af37;
+        color: var(--accent);
     }
     .fc-btn {
-        background: #d4af37;
+        background: var(--accent);
         color: #fff;
         border: none;
         padding: 10px 20px;

--- a/fun-casino.php
+++ b/fun-casino.php
@@ -8,6 +8,20 @@ Author: Silas
 
 if ( ! defined('ABSPATH') ) exit;
 
+// --------------------------------
+// Lade fc-template.php aus Plugin-Verzeichnis
+// --------------------------------
+add_filter('template_include', function($template){
+    if (is_page()) {
+        $slug = get_page_template_slug(get_queried_object_id());
+        if ($slug === 'fc-template.php') {
+            $file = plugin_dir_path(__FILE__) . 'fc-template.php';
+            if (file_exists($file)) return $file;
+        }
+    }
+    return $template;
+});
+
 // ------------------------------
 // Activation: create tables & pages
 // ------------------------------


### PR DESCRIPTION
## Summary
- Load `fc-template.php` from the plugin directory when selected as a page template
- Applies to both the FC Auth and Fun Casino plugins, removing theme headers/footers
- Unify minimal gold-accent design across plugin templates
- Allow user registration without an email, generating a placeholder address automatically

## Testing
- `php -l fc-auth.php`
- `php -l fun-casino.php`
- `php -l fc-template.php`


------
https://chatgpt.com/codex/tasks/task_e_68c81781acd483239d45307dfec21822